### PR TITLE
Updated dependencies and fixed fat JAR naming "-all-all" -> "-all" for

### DIFF
--- a/foundation/CDDBaselineJava/build.gradle
+++ b/foundation/CDDBaselineJava/build.gradle
@@ -16,7 +16,7 @@ version = '0.3'
 
 description = """"""
 
-def gradleDependencyVersion = '5.2'
+def gradleDependencyVersion = '5.3'
 
 wrapper {
     gradleVersion = gradleDependencyVersion
@@ -42,9 +42,9 @@ def guiceVersion = '4.2.2'
 def slf4jVersion = '1.7.25'
 def jacksonVersion = '2.9.8'
 def httpClientVersion = '4.5.7'
-def awsLambdaJavaCoreVersion = '1.2.0'
+def awsLambdaJavaCoreVersion = '1.1.0'
 def commonsIoVersion = '2.6'
-def awsSdkVersion = '1.11.519'
+def awsSdkVersion = '1.11.522'
 
 def libsDir = file("$buildDir/libs")
 def tempDir = file("$buildDir/temp")

--- a/functions/CDDBenchmarkJava/build.gradle
+++ b/functions/CDDBenchmarkJava/build.gradle
@@ -23,7 +23,7 @@ distTar.enabled = shadowDistTar.enabled = false
 mainClassName = 'not-necessary'
 
 group = 'CDDBenchmarkJava'
-version = '1.0-SNAPSHOT-all'
+version = '1.0-SNAPSHOT'
 
 description = """"""
 
@@ -35,7 +35,7 @@ tasks.withType(JavaCompile) {
 }
 
 wrapper {
-    gradleVersion = '5.2'
+    gradleVersion = '5.3'
 }
 
 lombok {
@@ -61,7 +61,7 @@ def commonsIoVersion = '2.6'
 def gsonVersion = '2.8.5'
 def guiceVersion = '4.2.2'
 def slf4jVersion = '1.7.25'
-def awsSdkVersion = '1.11.519'
+def awsSdkVersion = '1.11.522'
 def jacksonVersion = '2.9.7'
 def httpClientVersion = '4.5.6'
 def awsLambdaJavaCoreVersion = '1.2.0'

--- a/functions/CDDDMIJava/build.gradle
+++ b/functions/CDDDMIJava/build.gradle
@@ -23,7 +23,7 @@ distTar.enabled = shadowDistTar.enabled = false
 mainClassName = 'not-necessary'
 
 group = 'CDDDMIJava'
-version = '1.0-SNAPSHOT-all'
+version = '1.0-SNAPSHOT'
 
 description = """"""
 
@@ -35,7 +35,7 @@ tasks.withType(JavaCompile) {
 }
 
 wrapper {
-    gradleVersion = '5.2'
+    gradleVersion = '5.3'
 }
 
 lombok {
@@ -51,7 +51,7 @@ def commonsIoVersion = '2.6'
 def gsonVersion = '2.8.5'
 def guiceVersion = '4.2.2'
 def slf4jVersion = '1.7.25'
-def awsSdkVersion = '1.11.519'
+def awsSdkVersion = '1.11.522'
 def jacksonVersion = '2.9.7'
 def httpClientVersion = '4.5.6'
 def awsLambdaJavaCoreVersion = '1.2.0'

--- a/functions/CDDEmbeddedVaadinSkeletonJava/build.gradle
+++ b/functions/CDDEmbeddedVaadinSkeletonJava/build.gradle
@@ -23,7 +23,7 @@ distTar.enabled = shadowDistTar.enabled = false
 mainClassName = 'not-necessary'
 
 group = 'CDDEmbeddedVaadinSkeletonJava'
-version = '1.0-SNAPSHOT-all'
+version = '1.0-SNAPSHOT'
 
 description = """"""
 
@@ -35,7 +35,7 @@ tasks.withType(JavaCompile) {
 }
 
 wrapper {
-    gradleVersion = '5.2'
+    gradleVersion = '5.3'
 }
 
 lombok {
@@ -52,7 +52,7 @@ def commonsIoVersion = '2.6'
 def gsonVersion = '2.8.5'
 def guiceVersion = '4.2.2'
 def slf4jVersion = '1.7.25'
-def awsSdkVersion = '1.11.519'
+def awsSdkVersion = '1.11.522'
 def jacksonVersion = '2.9.7'
 def httpClientVersion = '4.5.6'
 def awsLambdaJavaCoreVersion = '1.2.0'

--- a/functions/CDDSenseHatJava/build.gradle
+++ b/functions/CDDSenseHatJava/build.gradle
@@ -23,7 +23,7 @@ distTar.enabled = shadowDistTar.enabled = false
 mainClassName = 'not-necessary'
 
 group = 'CDDSenseHatJava'
-version = '1.0-SNAPSHOT-all'
+version = '1.0-SNAPSHOT'
 
 description = """"""
 
@@ -35,7 +35,7 @@ tasks.withType(JavaCompile) {
 }
 
 wrapper {
-    gradleVersion = '5.2'
+    gradleVersion = '5.3'
 }
 
 lombok {
@@ -52,7 +52,7 @@ def commonsIoVersion = '2.6'
 def gsonVersion = '2.8.5'
 def guiceVersion = '4.2.2'
 def slf4jVersion = '1.7.25'
-def awsSdkVersion = '1.11.519'
+def awsSdkVersion = '1.11.522'
 def jacksonVersion = '2.9.7'
 def httpClientVersion = '4.5.6'
 def awsLambdaJavaCoreVersion = '1.2.0'

--- a/functions/CDDSkeletonJava/build.gradle
+++ b/functions/CDDSkeletonJava/build.gradle
@@ -23,7 +23,7 @@ distTar.enabled = shadowDistTar.enabled = false
 mainClassName = 'not-necessary'
 
 group = 'CDDSkeletonJava'
-version = '1.0-SNAPSHOT-all'
+version = '1.0-SNAPSHOT'
 
 description = """"""
 
@@ -35,7 +35,7 @@ tasks.withType(JavaCompile) {
 }
 
 wrapper {
-    gradleVersion = '5.2'
+    gradleVersion = '5.3'
 }
 
 lombok {
@@ -52,7 +52,7 @@ def guiceVersion = '4.2.2'
 def slf4jVersion = '1.7.25'
 def jacksonVersion = '2.9.7'
 def httpClientVersion = '4.5.6'
-def awsLambdaJavaCoreVersion = '1.2.0'
+def awsLambdaJavaCoreVersion = '1.1.0'
 def commonsIoVersion = '2.6'
 def junitVersion = '4.12'
 


### PR DESCRIPTION
Uber JAR naming was broken and caused GGP to omit dependencies from the bundle that was sent to AWS Lambda and therefore deployed on the core.  This has been fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
